### PR TITLE
added semicolon breakpoint character

### DIFF
--- a/lib/router.js
+++ b/lib/router.js
@@ -35,7 +35,7 @@ module.exports = function () {
       }
 
       var border = path[marker];
-      if (border !== undefined && border !== '/' && border !== '.') {
+      if (border !== undefined && border !== '/' && border !== '.' && border !== ';') {
         return next(error);
       }
 


### PR DESCRIPTION
So Node-router will route requests containing a semi-colon in the path.